### PR TITLE
point to Prorsum package with fix for get ecs credentials

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "CHTTPParser",
+        "repositoryURL": "https://github.com/Zewo/CHTTPParser.git",
+        "state": {
+          "branch": null,
+          "revision": "88306ab33bb316b2eedd39c90f4be8f4ebf65a11",
+          "version": "0.14.0"
+        }
+      },
+      {
         "package": "CLibreSSL",
         "repositoryURL": "https://github.com/vapor/clibressl.git",
         "state": {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/noppoMan/Prorsum.git",
         "state": {
           "branch": null,
-          "revision": "aab1cf5a01c1f936267fc6c55ac1bd7853767277",
-          "version": "0.3.1"
+          "revision": "b278e88142a3b5a87feabc44b6522dabfcda8f99",
+          "version": "0.3.3"
         }
       },
       {

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "AWSSDKSwiftCore", targets: ["AWSSDKSwiftCore"])
     ],
     dependencies: [
-        .package(url: "https://github.com/noppoMan/Prorsum.git", .upToNextMajor(from: "0.1.15")),
+        .package(url: "https://github.com/noppoMan/Prorsum.git", .upToNextMajor(from: "0.3.3")),
         .package(url: "https://github.com/noppoMan/HypertextApplicationLanguage.git", .upToNextMajor(from: "1.0.0"))
     ],
     targets: [

--- a/Sources/AWSSDKSwiftCore/AWSClient.swift
+++ b/Sources/AWSSDKSwiftCore/AWSClient.swift
@@ -183,7 +183,7 @@ extension AWSClient {
             headers[key.description] = value
         }
         
-        if self.signer.credentials.isEmpty() {
+        if self.signer.credentials.isEmpty() || self.signer.credentials.nearExpiration() {
             do {
                 signer.credentials = try MetaDataService().getCredential()
             } catch {

--- a/Sources/AWSSDKSwiftCore/Credential/Credential.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/Credential.swift
@@ -12,11 +12,21 @@ public protocol CredentialProvider {
     var accessKeyId: String { get }
     var secretAccessKey: String { get }
     var sessionToken: String? { get }
+    var expiration: Date? { get }
 }
 
-extension CredentialProvider {
+extension CredentialProvider {      
     public func isEmpty() -> Bool {
         return self.accessKeyId.isEmpty || self.secretAccessKey.isEmpty
+    }
+    
+    public func nearExpiration() -> Bool {
+      if let expiration = self.expiration {
+        // are we within 5 minutes of expiration?
+        return Date().addingTimeInterval(5.0 * 60.0) > expiration
+      } else {
+        return false
+      }
     }
 }
 
@@ -27,7 +37,8 @@ public struct SharedCredential: CredentialProvider {
     public let accessKeyId: String
     public let secretAccessKey: String
     public let sessionToken: String?
-    
+    public let expiration: Date? = nil
+        
     public init(filename: String = "~/.aws/credentials", profile: String = "default") throws {
         fatalError("Umimplemented")
         //let content = try String(contentsOfFile: filename)
@@ -38,18 +49,21 @@ public struct Credential: CredentialProvider {
     public let accessKeyId: String
     public let secretAccessKey: String
     public let sessionToken: String?
+    public let expiration: Date?
     
-    public init(accessKeyId: String, secretAccessKey: String, sessionToken: String? = nil) {
+    public init(accessKeyId: String, secretAccessKey: String, sessionToken: String? = nil, expiration: Date? = nil) {
         self.accessKeyId = accessKeyId
         self.secretAccessKey = secretAccessKey
         self.sessionToken = sessionToken ?? ProcessInfo.processInfo.environment["AWS_SESSION_TOKEN"]
+        self.expiration = expiration
     }
 }
 
 struct EnvironementCredential: CredentialProvider {
     let accessKeyId: String
     let secretAccessKey: String
-    public let sessionToken: String?
+    let sessionToken: String?
+    let expiration: Date? = nil
     
     init?() {
         guard let accessKeyId = ProcessInfo.processInfo.environment["AWS_ACCESS_KEY_ID"] else {

--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -16,69 +16,56 @@ enum MetaDataServiceError: Error {
 }
 
 struct MetaDataService {
-    struct MetaData {
-        let code: String
-        let lastUpdated: String
-        let type: String
-        let accessKeyId: String
-        let secretAccessKey: String
-        let token: String
-        let expiration: String
+  
+    static var container_credentials_uri = ProcessInfo.processInfo.environment["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
+    static let instance_metadata_uri = "/latest/meta-data/iam/security-credentials/"
+    
+    static var serviceHost: MetaDataServiceHost { 
+      get {
+        if container_credentials_uri != nil {
+          return .ECSCredentials(container_credentials_uri!)
+        } else { 
+          return .InstanceProfileCredentials(instance_metadata_uri)
+        }
+      }      
+    }
+  
+    enum MetaDataServiceHost {
+        case ECSCredentials(String)
+        case InstanceProfileCredentials(String)
         
-        var credential: Credential {
-            return Credential(
-                accessKeyId: accessKeyId,
-                secretAccessKey: secretAccessKey,
-                sessionToken: token
-            )
+        var baseURLString: String {
+            switch self {
+              case .ECSCredentials(let container_credentials_uri):
+                return "http://169.254.170.2\(container_credentials_uri)"
+              case .InstanceProfileCredentials(let instance_metadata_uri):
+                return "http://169.254.169.254\(instance_metadata_uri)"
+            }
         }
         
-        init(dictionary: [String: Any]) throws {
-            guard let code = dictionary["Code"] as? String else {
-                throw MetaDataServiceError.missingRequiredParam("Code")
+        func url() throws -> URL {
+          switch self {
+          case .ECSCredentials:
+            return URL(string: baseURLString)!
+          case .InstanceProfileCredentials:
+            let roleName = try getRoleName()
+            return URL(string: "\(baseURLString)/\(roleName)")!
+          }  
+        }
+        
+        func getRoleName() throws -> String {
+            let response = try MetaDataService.request(url: URL(string: baseURLString)!, timeout: 2)
+            switch response.statusCode {
+            case 200:
+                return String(data: response.body.asData(), encoding: .utf8) ?? ""
+            default:
+                throw MetaDataServiceError.couldNotGetInstanceRoleName
             }
-            
-            guard let lastUpdated = dictionary["LastUpdated"] as? String else {
-                throw MetaDataServiceError.missingRequiredParam("LastUpdated")
-            }
-            
-            guard let type = dictionary["Type"] as? String  else {
-                throw MetaDataServiceError.missingRequiredParam("Type")
-            }
-            
-            guard let accessKeyId = dictionary["AccessKeyId"] as? String  else {
-                throw MetaDataServiceError.missingRequiredParam("AccessKeyId")
-            }
-            
-            guard let secretAccessKey = dictionary["SecretAccessKey"] as? String  else {
-                throw MetaDataServiceError.missingRequiredParam("SecretAccessKey")
-            }
-            
-            guard let token = dictionary["Token"] as? String  else {
-                throw MetaDataServiceError.missingRequiredParam("Token")
-            }
-            
-            guard let expiration = dictionary["Expiration"] as? String  else {
-                throw MetaDataServiceError.missingRequiredParam("Expiration")
-            }
-            
-            self.code = code
-            self.lastUpdated = lastUpdated
-            self.type = type
-            self.accessKeyId = accessKeyId
-            self.secretAccessKey = secretAccessKey
-            self.token = token
-            self.expiration = expiration
         }
     }
     
-    let host = "169.254.169.254"
-    
-    var urlString: String {
-        return "http://\(host)/latest/meta-data/iam/security-credentials/"
-    }
-    
-    private func request(url: URL, timeout: TimeInterval) throws -> Response {
+    private static func request(url: URL, timeout: TimeInterval) throws -> Response {
+
         let chan = Channel<(Response?, Error?)>.make(capacity: 1)
         go {
             do {
@@ -90,11 +77,11 @@ struct MetaDataService {
                 do { try chan.send((nil, error)) } catch {}
             }
         }
-        
+
         var response: Response?
         var error: Error?
         let endAt = Date().addingTimeInterval(timeout)
-        
+
         forSelect { done in
             when(chan) { res, err in
                 response = res
@@ -102,7 +89,7 @@ struct MetaDataService {
                 chan.close()
                 done()
             }
-            
+
             otherwise {
                 if Date() > endAt {
                     error = MetaDataServiceError.connectionTimeout
@@ -111,31 +98,101 @@ struct MetaDataService {
                 }
             }
         }
-        
+
         if let e = error {
             throw e
         }
-        
+
         return response!
     }
-    
-    func getRoleName() throws -> String {
-        let response = try request(url: URL(string: self.urlString)!, timeout: 2)
-        switch response.statusCode {
-        case 200:
-            return String(data: response.body.asData(), encoding: .utf8) ?? ""
-        default:
-            throw MetaDataServiceError.couldNotGetInstanceRoleName
+
+    struct MetaData {
+        let accessKeyId: String
+        let secretAccessKey: String
+        let token: String
+        let expiration: Date
+
+        let code: String?
+        let lastUpdated: String?
+        let type: String?
+        let roleArn: String?
+
+        var credential: Credential {
+            return Credential(
+                accessKeyId: accessKeyId,
+                secretAccessKey: secretAccessKey,
+                sessionToken: token,
+                expiration: expiration
+            )
+        }
+
+        init(dictionary: [String: Any]) throws {
+            switch MetaDataService.serviceHost {
+            case .ECSCredentials:
+              self.code = nil
+              self.lastUpdated = nil
+              self.type = nil
+
+              guard let roleArn = dictionary["RoleArn"] as? String else {
+                  throw MetaDataServiceError.missingRequiredParam("RoleArn")
+              }
+              self.roleArn = roleArn
+
+            case .InstanceProfileCredentials:
+              self.roleArn = nil
+
+              guard let code = dictionary["Code"] as? String else {
+                  throw MetaDataServiceError.missingRequiredParam("Code")
+              }
+
+              guard let lastUpdated = dictionary["LastUpdated"] as? String else {
+                  throw MetaDataServiceError.missingRequiredParam("LastUpdated")
+              }
+
+              guard let type = dictionary["Type"] as? String  else {
+                  throw MetaDataServiceError.missingRequiredParam("Type")
+              }
+
+              self.code = code
+              self.lastUpdated = lastUpdated
+              self.type = type
+            }
+
+            guard let accessKeyId = dictionary["AccessKeyId"] as? String  else {
+                throw MetaDataServiceError.missingRequiredParam("AccessKeyId")
+            }
+
+            guard let secretAccessKey = dictionary["SecretAccessKey"] as? String  else {
+                throw MetaDataServiceError.missingRequiredParam("SecretAccessKey")
+            }
+
+            guard let token = dictionary["Token"] as? String  else {
+                throw MetaDataServiceError.missingRequiredParam("Token")
+            }
+
+            guard let expiration = dictionary["Expiration"] as? String  else {
+                throw MetaDataServiceError.missingRequiredParam("Expiration")
+            }
+
+            self.accessKeyId = accessKeyId
+            self.secretAccessKey = secretAccessKey
+            self.token = token
+            
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+            dateFormatter.timeZone = TimeZone(identifier: "UTC")
+            guard let date = dateFormatter.date(from: expiration) else {
+               fatalError("ERROR: Date conversion failed due to mismatched format.")
+            }
+            self.expiration = date
         }
     }
-    
+
     func getCredential() throws -> Credential {
-        let roleName = try getRoleName()
-        let url = URL(string: "\(urlString)/\(roleName)")!
-        let response = try request(url: url, timeout: 2)
+        let response = try MetaDataService.request(url: MetaDataService.serviceHost.url(), timeout: 2)
         let body: [String: Any] = try JSONSerialization.jsonObject(with: response.body.asData(), options: []) as? [String: Any] ?? [:]
         let metadata = try MetaData(dictionary: body)
-        
+
         return metadata.credential
     }
 }

--- a/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/MetaDataServiceTests.swift
@@ -1,0 +1,70 @@
+//
+//  MetaDataServiceTests.swift
+//  AWSSDKSwiftCoreTests
+//
+//  Created by Jonathan McAllister on 2017/12/29.
+//
+
+import Foundation
+import XCTest
+@testable import AWSSDKSwiftCore
+
+class MetaDataServiceTests: XCTestCase {
+  static var allTests : [(String, (MetaDataServiceTests) -> () throws -> Void)] {
+      return [
+        ("testMetaDataServiceForECSCredentials", testMetaDataServiceForECSCredentials),
+        ("testMetaDataServiceForInstanceProfileCredentials", testMetaDataServiceForInstanceProfileCredentials)
+      ]
+  }
+  
+  override func tearDown() {
+    MetaDataService.container_credentials_uri = nil
+  }
+
+  func testMetaDataServiceForECSCredentials() {
+    MetaDataService.container_credentials_uri = "/v2/credentials/5275a487-9ff6-49b7-b50c-b64850f99999"
+  
+    do {
+       let body: [String: Any] = ["RoleArn" : "arn:aws:iam::111222333444:role/mytask",
+                                  "AccessKeyId" : "ABCDEABCJOXYK7TPHCHTRKAA",
+                                  "SecretAccessKey" : "X+9PUEvV/xS2a7xQTg",
+                                  "Token" : "XYZ123dzENH//////////",
+                                  "Expiration" : "2017-12-30T13:22:39Z"]
+  
+       let metadata = try MetaDataService.MetaData(dictionary: body)
+       XCTAssertEqual(metadata.credential.accessKeyId, "ABCDEABCJOXYK7TPHCHTRKAA")
+  
+       let url = try MetaDataService.serviceHost.url()
+       guard let host = url.host else {
+         XCTFail("Error: host should not be nil")
+         return
+       }
+       XCTAssertEqual(host, "169.254.170.2")
+       XCTAssertEqual(url.path, "/v2/credentials/5275a487-9ff6-49b7-b50c-b64850f99999")
+    } catch {
+        XCTFail("\(error)")
+        return
+    }
+  }
+  
+  func testMetaDataServiceForInstanceProfileCredentials() { 
+    do {
+       let body: [String: Any] = ["Code" : "Success",
+                                  "LastUpdated" : "2018-01-05T05:25:41Z",
+                                  "Type" : "AWS-HMAC",
+                                  "AccessKeyId" : "XYZABCJOXYK7TPHCHTRKAA",
+                                  "SecretAccessKey" : "X+9PUEvV/xS2a7xQTg",
+                                  "Token" : "XYZ123dzENH//////////",
+                                  "Expiration" : "2017-12-30T13:22:39Z"]
+
+       let metadata = try MetaDataService.MetaData(dictionary: body)
+       XCTAssertEqual(metadata.credential.accessKeyId, "XYZABCJOXYK7TPHCHTRKAA")
+       
+       let baseURLString = MetaDataService.serviceHost.baseURLString
+       XCTAssertEqual(baseURLString, "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+    } catch {
+        XCTFail("\(error)")
+        return
+    }
+  }
+}

--- a/Tests/AWSSDKSwiftCoreTests/SignersV4Tests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/SignersV4Tests.swift
@@ -10,8 +10,8 @@ import Foundation
 import XCTest
 @testable import AWSSDKSwiftCore
 
-class SignersV4TestsTests: XCTestCase {
-    static var allTests : [(String, (SignersV4TestsTests) -> () throws -> Void)] {
+class SignersV4Tests: XCTestCase {
+    static var allTests : [(String, (SignersV4Tests) -> () throws -> Void)] {
         return [
             ("testHexEncodedBodyHash", testHexEncodedBodyHash),
             ("testSignedHeaders", testSignedHeaders),
@@ -23,7 +23,7 @@ class SignersV4TestsTests: XCTestCase {
             ("testSignedQuery", testSignedQuery)
         ]
     }
-    
+
     var requestDate: Date {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
@@ -32,15 +32,15 @@ class SignersV4TestsTests: XCTestCase {
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         return dateFormatter.date(from: "2017-01-01 00:00:00")!
     }
-    
+
     var timestamp: String {
         return Signers.V4.timestamp(requestDate)
     }
-    
+
     var credential: Credential {
         return Credential(accessKeyId: "key", secretAccessKey: "secret")
     }
-    
+
     func ec2Signer() -> (Signers.V4, URL, [String: String]) {
         let sign = Signers.V4(credentials: credential, region: .apnortheast1, service: "ec2")
         let host = "\(sign.service).\(sign.region).amazon.com"
@@ -48,52 +48,52 @@ class SignersV4TestsTests: XCTestCase {
         let headers: [String: String] = ["Host": host]
         return (sign, url, headers)
     }
-    
+
     func testHexEncodedBodyHash() {
         let helloDigest = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         let ec2sign = Signers.V4(credentials: credential, region: .apnortheast1, service: "ec2")
         XCTAssertEqual(ec2sign.hexEncodedBodyHash("hello".data(using: .utf8)!), helloDigest)
-        
+
         let s3sign = Signers.V4(credentials: credential, region: .apnortheast1, service: "s3")
         // if body data is empty, should return `UNSIGNED-PAYLOAD`
         XCTAssertEqual(s3sign.hexEncodedBodyHash(Data()), "UNSIGNED-PAYLOAD")
-        
+
         // if body data is not empty, should return body digest
         XCTAssertEqual(s3sign.hexEncodedBodyHash("hello".data(using: .utf8)!), helloDigest)
     }
-    
+
     func testSignedHeaders() {
         let (sign, url, _) = ec2Signer()
-        
+
         let headers = sign.signedHeaders(url: url, headers: [:], method: "POST", date: requestDate, bodyData: "hello".data(using: .utf8)!)
-        
+
         XCTAssertEqual(headers["Host"], "ec2.apnortheast1.amazon.com")
         XCTAssertEqual(headers["x-amz-content-sha256"], "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
         XCTAssertEqual(headers["x-amz-date"], "20170101T000000Z")
         XCTAssertEqual(headers["Authorization"], "AWS4-HMAC-SHA256 Credential=key/20170101/ap-northeast-1/ec2/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=7c6c37e1cbfd7f7594a55dfbc25c49e1ada0b4898f4add6160f6346f40936015")
     }
-    
+
     func testCredential() {
         let (sign, _, _) = ec2Signer()
         XCTAssertEqual(sign.credential(timestamp), "key/20170101/ap-northeast-1/ec2/aws4_request")
     }
-    
+
     func testStringToSign() {
         let (sign, url, httpHeaders) = ec2Signer()
         let stringToSign = sign.stringToSign(url: url, headers: httpHeaders, datetime: timestamp, method: "PUT", bodyDigest: sha256("hello").hexdigest())
-        
+
         let splited = stringToSign.components(separatedBy: "\n")
         XCTAssertEqual(splited[0], "AWS4-HMAC-SHA256")
         XCTAssertEqual(splited[1], "20170101T000000Z")
         XCTAssertEqual(splited[2], "20170101/ap-northeast-1/ec2/aws4_request")
         XCTAssertEqual(splited[3], "13c4a719e774503a37696180fa98caecf7ac29200128f217e337d417f80a4860")
     }
-    
+
     func testCanonicalRequest() {
         let (sign, url, httpHeaders) = ec2Signer()
         let bodyDigest = sha256("hello").hexdigest()
         let canonicalRequest = sign.canonicalRequest(url: url, headers: httpHeaders, method: "PUT", bodyDigest: bodyDigest)
-        
+
         let splited = canonicalRequest.components(separatedBy: "\n")
         XCTAssertEqual(splited[0], "PUT")
         XCTAssertEqual(splited[1], "/foo")
@@ -103,33 +103,32 @@ class SignersV4TestsTests: XCTestCase {
         XCTAssertEqual(splited[5], "host")
         XCTAssertEqual(splited[6], "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
     }
-    
+
     func testSignature() {
         let (sign, url, httpHeaders) = ec2Signer()
         let bodyDigest = sha256("hello").hexdigest()
         let signature = sign.signature(url: url, headers: httpHeaders, datetime: timestamp, method: "PUT", bodyDigest: bodyDigest)
         XCTAssertEqual(signature, "4a2fc55d5e517133a8dae28752f36851e77f291221095ee9fb4cfcff8ac63dd9")
     }
-    
+
     func testSignedHeadersForS3() {
         let sign = Signers.V4(credentials: credential, region: .apnortheast1, service: "s3")
         let host = "\(sign.service)-\(sign.region).amazon.com"
         let url = URL(string: "https://\(host)")!
         let headers = sign.signedHeaders(url: url, headers: [:], method: "PUT", date: requestDate, bodyData: Data())
-        
+
         XCTAssertEqual(headers["Host"], "s3-apnortheast1.amazon.com")
         XCTAssertEqual(headers["x-amz-content-sha256"], "UNSIGNED-PAYLOAD")
         XCTAssertEqual(headers["x-amz-date"], "20170101T000000Z")
         XCTAssertEqual(headers["Authorization"], "AWS4-HMAC-SHA256 Credential=key/20170101/ap-northeast-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=dcd1b4bbe822227213a38c745eb511a7a017c2709e34af88838a1c8d659ec57a")
     }
-    
+
     func testSignedQuery() {
         let sign = Signers.V4(credentials: credential, region: .apnortheast1, service: "s3")
         let host = "\(sign.service)-\(sign.region).amazon.com"
         let url = URL(string: "https://\(host)")!
         let signedURL = sign.signedURL(url: url, date: requestDate)
-        
+
         XCTAssertEqual(signedURL.absoluteString, "https://s3-apnortheast1.amazon.com?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=key%2F20170101%2Fap-northeast-1%2Fs3%2Faws4_request&X-Amz-Date=20170101T000000Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=c3c920a3b89cb39b01ef6f99228e4cfae5fc8a4ab5de9c5b4ad96e9b05ee0f61")
     }
 }
-

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,8 +3,9 @@ import XCTest
 
 XCTMain([
      testCase(SerializersTests.allTests),
-     testCase(SignersV4TestsTests.allTests),
+     testCase(SignersV4Tests.allTests),
      testCase(XML2ParserTests.allTests),
      testCase(DictionaryDecoderTests.allTests),
-     testCase(TimeStampTests.allTests)
+     testCase(TimeStampTests.allTests),
+     testCase(MetaDataServiceTests.allTests)
 ])


### PR DESCRIPTION
detect if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is present
and set static var serviceHost to enum MetaDataServiceHost

determine logic to getCredentials in MetaDataService from
serviceHost

add support for Expiration on Credential

check if Credential is nearExpiration and call getCredential
if within 5 mins or Expiration is past