### PR TITLE
Middleware - Signing Issue Fix

### DIFF
--- a/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
+++ b/Sources/AWSSDKSwiftCore/Message/AWSRequest.swift
@@ -86,12 +86,7 @@ public struct AWSRequest {
             headers["Content-Type"] = "application/octet-stream"
         }
 
-        var uri = !awsRequest.url.path.isEmpty ? awsRequest.url.path : "/"
-        if let query = awsRequest.url.query {
-            uri += "?\(query)"
-        }
-
-        var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: HTTPMethod.RAW(value: awsRequest.httpMethod), uri: uri)
+        var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: HTTPMethod.RAW(value: awsRequest.httpMethod), uri: awsRequest.url.absoluteString)
         let generatedHeaders = headers.map { ($0, $1) }
         head.headers = HTTPHeaders(generatedHeaders)
 


### PR DESCRIPTION
Removed logic that would set nioRequest.head.uri to awsRequest.url.path + query.   nioRequest.head.uri will now be set to awsRequest.url.absoluteString.

Removed url: parameter from AWSClient.nioRequestWithSignedHeader(_:) in order to insure that all request transformations are handled by AWSRequest.toNIORequest().

These two changes were made in order to prevent the case in which AWSRequestMiddleware and Signer would receive different URLs.  (cough S3 cough)